### PR TITLE
The connection with the Sparql database should be set up in ::bootEnvironment()

### DIFF
--- a/tests/src/Kernel/SparqlKernelTestBase.php
+++ b/tests/src/Kernel/SparqlKernelTestBase.php
@@ -28,9 +28,16 @@ class SparqlKernelTestBase extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
+  protected function bootEnvironment() {
+    parent::bootEnvironment();
+    $this->setUpSparql();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp(): void {
     parent::setUp();
-    $this->setUpSparql();
     $this->installConfig(['sparql_entity_storage', 'sparql_test']);
   }
 

--- a/tests/src/Kernel/SparqlSerializerTest.php
+++ b/tests/src/Kernel/SparqlSerializerTest.php
@@ -32,9 +32,16 @@ class SparqlSerializerTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
+  protected function bootEnvironment() {
+    parent::bootEnvironment();
+    $this->setUpSparql();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     parent::setUp();
-    $this->setUpSparql();
     $this->installConfig(['sparql_entity_storage', 'sparql_entity_serializer_test']);
   }
 


### PR DESCRIPTION
Currently it is being set up after calling `parent::setUp()` but this is too late since at this point the container has already been built, and services might be accessing storage. We should call this instead in `::bootEnvironment()`, the method in which the regular SQL storage is also set up.