### PR TITLE
Replace deprecated calls to PhpunitCompatibilityTrait::setExpectedException()

### DIFF
--- a/tests/src/Kernel/EntityCreationTest.php
+++ b/tests/src/Kernel/EntityCreationTest.php
@@ -41,7 +41,8 @@ class EntityCreationTest extends SparqlKernelTestBase {
 
     // Check that the expected exception is throw when trying to create a new
     // entity with the same ID.
-    $this->setExpectedException(DuplicatedIdException::class, "Attempting to create a new entity with the ID 'http://example.com/apple' already taken.");
+    $this->expectException(DuplicatedIdException::class);
+    $this->expectExceptionMessage("Attempting to create a new entity with the ID 'http://example.com/apple' already taken.");
     SparqlTest::create([
       'type' => 'fruit',
       'id' => 'http://example.com/apple',

--- a/tests/src/Kernel/EntityLanguageTest.php
+++ b/tests/src/Kernel/EntityLanguageTest.php
@@ -73,7 +73,8 @@ class EntityLanguageTest extends SparqlKernelTestBase {
     $this->assertEquals('Τυχαιο κειμενο', $entity->text->value);
 
     // Verify that the translation is deleted.
-    $this->setExpectedException('\InvalidArgumentException', "Invalid translation language (el) specified.");
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Invalid translation language (el) specified.');
     $entity->getTranslation('el');
   }
 

--- a/tests/src/Kernel/SparqlEntityQueryTest.php
+++ b/tests/src/Kernel/SparqlEntityQueryTest.php
@@ -162,28 +162,32 @@ class SparqlEntityQueryTest extends SparqlKernelTestBase {
     $this->assertResult('http://vegetable.example.com/001');
 
     // Try to fetch a NULL ID.
-    $this->setExpectedException('Exception', 'The value cannot be NULL for conditions related to the Id and bundle keys.');
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('The value cannot be NULL for conditions related to the Id and bundle keys.');
     $this->results = $this->getQuery()
       ->condition('id', NULL)
       ->condition('type', 'vegetable')
       ->execute();
 
     // Try to filter ID with an invalid operator.
-    $this->setExpectedException('Exception', "Only '=', '!=', '<>', 'IN', 'NOT IN' operators are allowed for the Id and bundle keys.");
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage("Only '=', '!=', '<>', 'IN', 'NOT IN' operators are allowed for the Id and bundle keys.");
     $this->results = $this->getQuery()
       ->condition('id', 'http://vegetable.example.com/003', 'LIKE')
       ->condition('type', 'vegetable')
       ->execute();
 
     // Try to fetch a NULL bundle.
-    $this->setExpectedException('Exception', 'The value cannot be NULL for conditions related to the Id and bundle keys.');
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('The value cannot be NULL for conditions related to the Id and bundle keys.');
     $this->results = $this->getQuery()
       ->condition('id', 'http://vegetable.example.com/002')
       ->condition('type', NULL)
       ->execute();
 
     // Try to filter bundle with an invalid operator.
-    $this->setExpectedException('Exception', "Only '=', '!=', '<>', 'IN', 'NOT IN' operators are allowed for the Id and bundle keys.");
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage("Only '=', '!=', '<>', 'IN', 'NOT IN' operators are allowed for the Id and bundle keys.");
     $this->results = $this->getQuery()
       ->condition('id', 'http://vegetable.example.com/003')
       ->condition('type', 'multi', 'STARTS WITH')

--- a/tests/src/Kernel/SparqlGraphTest.php
+++ b/tests/src/Kernel/SparqlGraphTest.php
@@ -128,7 +128,8 @@ class SparqlGraphTest extends SparqlKernelTestBase {
     $this->assertNotContains('non_existing_graph', $default_graphs);
 
     // Try to request the entity from a non-existing graph.
-    $this->setExpectedException(\InvalidArgumentException::class, "Graph 'invalid graph' doesn't exist for entity type 'sparql_test'.");
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage("Graph 'invalid graph' doesn't exist for entity type 'sparql_test'.");
     $storage->load($id, ['invalid graph', 'default', 'foo']);
   }
 


### PR DESCRIPTION
When running tests the following deprecation notices are thrown:

```
Remaining self deprecation notices (4)

  4x: \Drupal\Tests\PhpunitCompatibilityTrait:setExpectedException() is deprecated in drupal:8.8.0 and is removed from drupal:9.0.0. Backward compatibility for PHPUnit 4 will no longer be supported. See https://www.drupal.org/node/3056869
    1x in EntityCreationTest::testOverlappingIds from Drupal\Tests\sparql_entity_storage\Kernel
    1x in EntityLanguageTest::testEntityTranslation from Drupal\Tests\sparql_entity_storage\Kernel
    1x in SparqlEntityQueryTest::testIdBundleFilters from Drupal\Tests\sparql_entity_storage\Kernel
    1x in SparqlGraphTest::test from Drupal\Tests\sparql_entity_storage\Kernel
```