### PR TITLE
ISAICP-6152: Optimize the query condition

### DIFF
--- a/src/Entity/Query/Sparql/SparqlCondition.php
+++ b/src/Entity/Query/Sparql/SparqlCondition.php
@@ -382,7 +382,7 @@ class SparqlCondition extends ConditionFundamentals implements ConditionInterfac
           $this->fieldMappingConditions[] = [
             'field' => $condition['field'],
             'column' => $condition['column'],
-            'value' => array_values($mappings),
+            'value' => array_unique(array_values($mappings)),
             'operator' => 'IN',
           ];
         }


### PR DESCRIPTION
The condition creates too many predicate duplicates.

With the current code, the following entity query:

```php
\Drupal::entityQuery('rdf_entity')
  ->condition('label', 'whatever')
  ->execute();
```

will produce this SPARQL query:

```sparql
SELECT DISTINCT(?entity)
  FROM <http://joinup.eu/asset_distribution/published>
  FROM <http://joinup.eu/asset_release/published>
  FROM <http://joinup.eu/asset_release/draft>
  FROM <http://joinup.eu/collection/published>
  FROM <http://joinup.eu/collection/draft>
  FROM <http://joinup.eu/contact-information/published>
  FROM <http://joinup.eu/licence/published>
  FROM <http://joinup.eu/owner/published>
  FROM <http://joinup.eu/provenance_activity>
  FROM <http://joinup.eu/solution/published>
  FROM <http://joinup.eu/solution/draft>
  FROM <http://joinup.eu/spdx_licence/published>
  WHERE {
    ?entity ?label__value_predicate "whatever"@en .
    ?entity ?label__value_predicate ?label__value .
    VALUES ?label__value_predicate {
      <http://purl.org/dc/terms/title>
      <http://purl.org/dc/terms/title>
      <http://purl.org/dc/terms/title>
      <http://purl.org/dc/terms/title>
      <http://www.w3.org/2000/01/rdf-schema#label>
      <http://purl.org/dc/terms/title>
      <http://purl.org/dc/terms/title>
      <http://purl.org/dc/terms/title>
      <http://spdx.org/rdf/terms#name>
    }
  }
```

We improve the `VALUES` clause by removing duplicates. The query becomes:

```sparql
SELECT DISTINCT(?entity)
  FROM <http://joinup.eu/asset_distribution/published>
  FROM <http://joinup.eu/asset_release/published>
  FROM <http://joinup.eu/asset_release/draft>
  FROM <http://joinup.eu/collection/published>
  FROM <http://joinup.eu/collection/draft>
  FROM <http://joinup.eu/contact-information/published>
  FROM <http://joinup.eu/licence/published>
  FROM <http://joinup.eu/owner/published>
  FROM <http://joinup.eu/provenance_activity>
  FROM <http://joinup.eu/solution/published>
  FROM <http://joinup.eu/solution/draft>
  FROM <http://joinup.eu/spdx_licence/published>
  WHERE {
    ?entity ?label__value_predicate "whatever"@en .
    ?entity ?label__value_predicate ?label__value .
    VALUES ?label__value_predicate {
      <http://purl.org/dc/terms/title>
      <http://www.w3.org/2000/01/rdf-schema#label>
      <http://spdx.org/rdf/terms#name>
    }
  }
```
