### PR TITLE
Optimize the entity query

### DIFF
--- a/src/SparqlEntityStorageGraphHandlerInterface.php
+++ b/src/SparqlEntityStorageGraphHandlerInterface.php
@@ -138,7 +138,7 @@ interface SparqlEntityStorageGraphHandlerInterface {
    *   (optional) A list of graph IDs to limit the results. NULL means that all
    *   graphs are allowed. Defaults to NULL.
    *
-   * @return string[]
+   * @return string[][]
    *   A list of graph URIs.
    */
   public function getEntityTypeGraphUris(string $entity_type_id, array $limit_to_graph_ids = NULL): array;


### PR DESCRIPTION
When one or more bundle conditions are passed to the entity query, there's no need to search all available graphs. Instead, the SPARQL query can be optimized.

Let's take this entity query:

```php
\Drupal::entityQuery('rdf_entity')
  ->condition('rid', 'collection')
  ->execute();
```

Currently this produces the following SPARQL query:

```sparql
SELECT DISTINCT(?entity)
  FROM <http://joinup.eu/asset_distribution/published>
  FROM <http://joinup.eu/asset_release/published>
  FROM <http://joinup.eu/asset_release/draft>
  FROM <http://joinup.eu/collection/published>
  FROM <http://joinup.eu/collection/draft>
  FROM <http://joinup.eu/contact-information/published>
  FROM <http://joinup.eu/licence/published>
  FROM <http://joinup.eu/owner/published>
  FROM <http://joinup.eu/provenance_activity>
  FROM <http://joinup.eu/solution/published>
  FROM <http://joinup.eu/solution/draft>
  FROM <http://joinup.eu/spdx_licence/published>
WHERE {
  ?entity <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?rid .
  VALUES ?rid {<http://www.w3.org/ns/dcat#Catalog>}
}
```

But, as a bundle condition is present we know that we should search only in `http://joinup.eu/collection/published` and `http://joinup.eu/collection/draft`. With this PR, the query becomes:

```sparql
SELECT DISTINCT(?entity)
  FROM <http://joinup.eu/collection/published>
  FROM <http://joinup.eu/collection/draft>
WHERE {
  ?entity <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?rid .
  VALUES ?rid {<http://www.w3.org/ns/dcat#Catalog>}
}
```

Faster!

A more complex query:
```php
\Drupal::entityQuery('rdf_entity')
  ->condition('rid', 'asset_release', '=')
  ->condition('rid', 'licence', '!=')
  ->condition('rid', ['collection', 'solution'], 'IN')
  ->execute();
```
will result in:
```sparql
SELECT DISTINCT(?entity)
  FROM <http://joinup.eu/asset_release/published>
  FROM <http://joinup.eu/asset_release/draft>
  FROM <http://joinup.eu/collection/published>
  FROM <http://joinup.eu/collection/draft>
  FROM <http://joinup.eu/solution/published>
  FROM <http://joinup.eu/solution/draft>
WHERE {
  ?entity <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?rid .
  VALUES ?rid {<http://www.w3.org/ns/dcat#Dataset>} .
  VALUES ?rid {<http://www.w3.org/ns/dcat#Catalog> <http://www.w3.org/ns/dcat#Dataset>} .
  FILTER (?rid NOT IN (<http://purl.org/dc/terms/LicenseDocument>))
}
```

A 'NOT IN' query:

```php
\Drupal::entityQuery('rdf_entity')
  ->condition('rid', ['collection', 'solution'], 'NOT IN')
  ->execute();
```

gives

```sparql
SELECT DISTINCT(?entity)
  FROM <http://joinup.eu/asset_distribution/published>
  FROM <http://joinup.eu/asset_release/published>
  FROM <http://joinup.eu/asset_release/draft>
  FROM <http://joinup.eu/contact-information/published>
  FROM <http://joinup.eu/licence/published>
  FROM <http://joinup.eu/owner/published>
  FROM <http://joinup.eu/provenance_activity>
  FROM <http://joinup.eu/spdx_licence/published>
WHERE {
  ?entity <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?rid .
  FILTER NOT EXISTS {?entity <http://purl.org/dc/terms/isVersionOf> ?field_isr_is_version_of__target_id} .
  FILTER (?rid NOT IN (<http://www.w3.org/ns/dcat#Catalog>, <http://www.w3.org/ns/dcat#Dataset>))
}
```
Still many graphs but not all.